### PR TITLE
Wall

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,13 +1,43 @@
 # SocialNetwork
 
 ### Posting
-A User has the ability to Post via commandline input, in the form {username} -> {message}.
+A User has the ability to Post via commandline input, in the form `{username} -> {message}`.
 
 The User is created if it doesn't already exist.
+
+### Reading
+A User has the ability to see their Posts by typing their name at the input. For example:
+
+`> Liam -> everything is awesome!`
+`> Liam`
+
+`everything is awesome! (0 minutes ago)`
+
+### Following
+A User can follow another User by inputting `{User} follows {User}`.
+
+`> Liam -> everything is awesome!`
+`> Joe -> everything could be awesome, research not complete`
+`> Liam follows Joe` -- Liam is now following Joe
+
+### Wall
+A User has the ability to see all Posts from itself and Users it is following via the Wall command.
+
+`> Liam -> everything is awesome!`
+`> Joe -> everything could be awesome, research not complete`
+`> Liam follows Joe`
+`> Sarah -> new research indicates some things may not be awesome`
+`> Liam follows Sarah`
+`> Liam wall`
+
+`Sarah - new research indicates some things may not be awesome (0 minutes ago)`
+`Joe - everything could be awesome, research not complete (5 minutes ago)`
+`Liam - everything is awesome! (7 minutes ago)`
 
 ### Classes
 **User** - holds metadata for each User
 
 **Post** - holds a message content and time of the post.
 
-**Timeline** - In-memory store for Posts for a User 
+**Timeline** - In-memory store for Posts
+

--- a/SocialNetwork.Core.Tests/Post_Tests.cs
+++ b/SocialNetwork.Core.Tests/Post_Tests.cs
@@ -18,5 +18,27 @@ namespace SocialNetwork.Core.Tests
             Assert.AreEqual(testMessage, mockPost.Content);
             Assert.AreEqual(mockPostedDateTime, mockPost.PostedDateTime);
         }
+
+        [TestMethod]
+        public void ToOutputFormat_returns_output_friendly_Post()
+        {
+            string testMessage = "Everything is awesome";
+
+            Post testPost = new Post(testMessage);
+            
+            Assert.AreEqual($"{testMessage} (0 minutes ago)", testPost.ToOutputFormat());
+        }
+
+        [TestMethod]
+        public void ToOutputFormat_returns_correct_grammar_for_post_one_minute_ago()
+        {
+            string testMessage = "Everything may or may not be awesome";
+
+            PostWithFixedDateTime postOneMinuteAgo = new PostWithFixedDateTime(
+                testMessage,
+                DateTime.UtcNow.AddMinutes(-1));
+            
+            Assert.AreEqual($"{testMessage} (1 minute ago)", postOneMinuteAgo.ToOutputFormat());
+        }
     }
 }

--- a/SocialNetwork.Core.Tests/Timeline_Tests.cs
+++ b/SocialNetwork.Core.Tests/Timeline_Tests.cs
@@ -9,32 +9,6 @@ namespace SocialNetwork.Core.Tests
     public class Timeline_Tests
     {
         [TestMethod]
-        public void FormatPost_returns_output_friendly_Post()
-        {
-            string testMessage = "Everything is awesome";
-
-            Post testPost = new Post(testMessage);
-
-            string formattedPost = new Timeline().FormatPost(testPost);
-
-            Assert.AreEqual($"{testMessage} (0 minutes ago)", formattedPost);
-        }
-
-        [TestMethod]
-        public void FormatPost_returns_correct_grammar_for_post_one_minute_ago()
-        {
-            string testMessage = "Everything may or may not be awesome";
-
-            PostWithFixedDateTime postOneMinuteAgo = new PostWithFixedDateTime(
-                testMessage, 
-                DateTime.UtcNow.AddMinutes(-1));
-
-            string formattedPost = new Timeline().FormatPost(postOneMinuteAgo);
-
-            Assert.AreEqual($"{testMessage} (1 minute ago)", formattedPost);
-        }
-
-        [TestMethod]
         public void GetTimeline_returns_formatted_collection_of_posts()
         {
             string testMessage  = "Unable to ascertain the awesomeness of everything";
@@ -42,8 +16,8 @@ namespace SocialNetwork.Core.Tests
 
             Timeline testTimeline = new Timeline();
 
-            testTimeline.AddPost(new Post(testMessage));
-            testTimeline.AddPost(
+            testTimeline.Posts.Add(new Post(testMessage));
+            testTimeline.Posts.Add(
                 new PostWithFixedDateTime(testMessage2, DateTime.UtcNow.AddMinutes(-10)));
 
             IEnumerable<string> formattedPosts = testTimeline.GetTimeline();

--- a/SocialNetwork.Core/Post.cs
+++ b/SocialNetwork.Core/Post.cs
@@ -14,5 +14,14 @@ namespace SocialNetwork.Core
             this.Content = content;
             this.PostedDateTime = DateTime.UtcNow;
         }
+
+        public string ToOutputFormat()
+        {
+            int minutesAgo = (DateTime.UtcNow - this.PostedDateTime).Minutes;
+
+            string plural = minutesAgo == 1 ? string.Empty : "s";
+
+            return $"{this.Content} ({minutesAgo} minute{plural} ago)";
+        }
     }
 }

--- a/SocialNetwork.Core/Timeline.cs
+++ b/SocialNetwork.Core/Timeline.cs
@@ -6,19 +6,9 @@ namespace SocialNetwork.Core
 {
     public class Timeline
     {
-        private readonly List<Post> _posts = new List<Post>();
-
-        public void AddPost(Post post) => this._posts.Add(post);
-
-        public string FormatPost(Post post)
-        {
-            int minutesAgo = (DateTime.UtcNow - post.PostedDateTime).Minutes;
-
-            string plural = minutesAgo == 1 ? string.Empty : "s";
-
-            return $"{post.Content} ({minutesAgo} minute{plural} ago)";
-        }
-
-        public IEnumerable<string> GetTimeline() => this._posts.Select(this.FormatPost);
+        public List<Post> Posts = new List<Post>();
+        
+        public IEnumerable<string> GetTimeline() => 
+            this.Posts.Select(p => p.ToOutputFormat());
     }
 }

--- a/SocialNetwork/Program.cs
+++ b/SocialNetwork/Program.cs
@@ -25,6 +25,9 @@ namespace SocialNetwork
                 else if (userInput.Contains("follows"))
                     AddUserToFollowingForUser(userInput);
 
+                else if (userInput.Contains("wall"))
+                    DisplayWall(userInput);
+
                 else if (!userInput.Contains(" "))
                     DisplayTimeline(userInput);
             }
@@ -39,7 +42,7 @@ namespace SocialNetwork
 
             if (user != null)
             {
-                user.Timeline.AddPost(new Post(parsedInput[1]));
+                user.Timeline.Posts.Add(new Post(parsedInput[1]));
             }
             else
             {
@@ -47,7 +50,7 @@ namespace SocialNetwork
 
                 Users.Add(newUser);
 
-                newUser.Timeline.AddPost(new Post(parsedInput[1]));
+                newUser.Timeline.Posts.Add(new Post(parsedInput[1]));
             }
         }
 
@@ -59,7 +62,7 @@ namespace SocialNetwork
 
             IEnumerable<string> userTimeline = user.Timeline.GetTimeline().Reverse();
 
-            Console.WriteLine(string.Join("\n", userTimeline));
+            Console.WriteLine(string.Join(Environment.NewLine, userTimeline));
         }
 
 
@@ -72,7 +75,36 @@ namespace SocialNetwork
             User userToFollow = Users.FirstOrDefault(u => u.Name == parsedInput[1]);
 
             if (userToFollow != null)
+            {
                 user?.Following.Add(userToFollow);
+            }
+                
+        }
+
+        private static void DisplayWall(string userInput)
+        {
+            string[] parsedInput = Regex.Split(userInput, " wall");
+
+            User user = Users.FirstOrDefault(u => u.Name == parsedInput[0]);
+
+            if (user == null) return;
+
+            List<Tuple<string, Post>> wall = new List<Tuple<string, Post>>();
+
+            wall.AddRange(user.Timeline.Posts.Select(
+                post => new Tuple<string, Post>(user.Name, post)));
+
+            foreach (User u in user.Following)
+            {
+                wall.AddRange(
+                    u.Timeline.Posts.Select(
+                        post => new Tuple<string, Post>(u.Name, post)));
+            }
+            
+            foreach (Tuple<string, Post> p in wall.OrderByDescending(t => t.Item2.PostedDateTime))
+            {
+                Console.WriteLine($"{p.Item1} - {p.Item2.ToOutputFormat()}");
+            }
         }
     }
 }


### PR DESCRIPTION
Several things I see now this resolves #7, and the four commands have been implemented:
- The worker functions in Program.cs can and should be tested. They could return the output rather than talk to the Console directly for ease of testing
- Implementing the Wall as a List of Tuples is clunky. 'Item1' and 'Item2' are not clear namings. The fact that this was the easiest way I could think of implementing the Wall shows that I should refactor some of the classes (should a Post have a reference to it's User?)
- The Post class should hold the FormatPost function, as a Post should be in charge of it's friendly output (this is fixed in this PR, and renamed ToOutputFormat).
- The Main method in Program.cs shouldn't part of the parsing logic. A good idea might be to pass the input to a deciding method which returns an Enum. Perhaps RequestType.Follow, RequestType.Wall etc
